### PR TITLE
Optimisation to fit atg model parameters.

### DIFF
--- a/graphs/fit_atg_model.py
+++ b/graphs/fit_atg_model.py
@@ -1,0 +1,81 @@
+from dataclasses import dataclass
+from typing import List
+
+import numpy as np
+import pytest
+from scipy.optimize import least_squares
+
+# TODO(miskosz): Pass in as a parameter?
+EXPONENT = 6.23
+
+@dataclass
+class AtgModelFit:
+    """
+    Result of fitting (x, y) data samples to the curve:
+        y = (a/tg) * (x/tg)^6.23 * e^(-x/tg)
+    
+    TODO(miskosz): Maybe return also something like a standard deviation of the fit.
+    """
+    a: float
+    tg: float
+
+    def predict(self, x: float) -> float:
+        ys = _model(params=[self.a, self.tg], xs=[x])
+        return ys[0]
+
+
+def fit_atg_model(xs: np.ndarray, ys: np.ndarray) -> AtgModelFit:
+    """
+    Fits atg model through `(xs, ys)` datapoints.
+    """
+    assert len(xs) == len(ys), "Inconsistent number of datapoints to fit."
+    assert np.all(xs > 0), "No support for non-positive values for `xs`."
+    assert np.all(ys >= 0), "No support for negative values for `ys`."
+    a0 = 2000.0
+    tg0 = 7.0
+    # TODO(miskosz): Handle failures.
+    least_squares_result = least_squares(fun=_residuals, x0=[a0, tg0], args=(xs, ys))
+    return AtgModelFit(a=least_squares_result.x[0], tg=least_squares_result.x[1])
+
+
+def _residuals(params: List[float], xs: np.ndarray, ys: np.ndarray) -> float:
+    """
+    Returns the residual ("error") of model fitting with parameter values `params`
+    to the datapoints (xs, ys).
+
+    NOTE: We compute the logarithm in logspace since the data spans multiple orders.
+    We don't care if the model is off by 10 for values close to 20000, but we care
+    for small values. We choose natural base of the logarithm.
+    """
+    return np.log(1. + _model(params=params, xs=xs)) - np.log(1. + ys)
+
+
+def _model(params: List[float], xs: np.ndarray) -> np.ndarray:
+    """
+    Returns predicted y-values of the model
+        y = (a/tg) * (x/tg)^6.23 * e^(-x/tg)
+    with parameters `params` for the values `x` in `xs`, where `a=params[0]` and `tg=params[1]`.
+    """
+    a, tg = params
+    # Note(miskosz): Optimise `tg` in logspace if the following line becomes a problem.
+    assert tg > 0, f"No support for negative values for `tg` (tg={tg})."
+    return (a/tg) * (xs/tg)**EXPONENT * np.exp(-xs/tg)
+
+
+# Note(miskosz): Lousy test at the bottom of the file O:)
+# TODO(miskosz): Add a testing script. Atm can be tested by `pytest graphs/fit_atg_model.py`.
+def test_fit_atg_model():
+    a = 2719.0
+    tg = 7.2
+    xs = np.arange(1, 100)
+
+    # Test perfect fit.
+    ys = _model(params=[a, tg], xs=xs)
+    fit = fit_atg_model(xs=xs, ys=ys)
+    assert np.allclose([fit.a, fit.tg], [a, tg])
+
+    # Test noisy fit.
+    ys += np.random.rand(len(ys))
+    fit = fit_atg_model(xs=xs, ys=ys)
+    assert fit.a == pytest.approx(a, rel=0.1)
+    assert fit.tg == pytest.approx(tg, rel=0.1)

--- a/graphs/fit_atg_model_test.py
+++ b/graphs/fit_atg_model_test.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pytest
+
+import fit_atg_model
+
+def test_fit_atg_model():
+    a = 2719.0
+    tg = 7.2
+    xs = np.arange(1, 100)
+
+    # Test perfect fit.
+    ys = fit_atg_model._model(params=[a, tg], xs=xs)
+    fit = fit_atg_model.fit_atg_model(xs=xs, ys=ys)
+    assert np.allclose([fit.a, fit.tg], [a, tg])
+
+    # Test a noisy fit.
+    ys += np.random.rand(len(ys))
+    fit = fit_atg_model.fit_atg_model(xs=xs, ys=ys)
+    assert fit.a == pytest.approx(a, rel=0.1)
+    assert fit.tg == pytest.approx(tg, rel=0.1)
+
+    # Test with real-world data. (UK active since 2020-3-7.)
+    xs = np.arange(1, 27)
+    ys = np.array([
+        186.,
+        252.,
+        299.,
+        358.,
+        430.,
+        430.,
+        772.,
+        1101.,
+        1101.,
+        1468.,
+        1843.,
+        2490.,
+        2487.,
+        3741.,
+        4720.,
+        5337.,
+        6250.,
+        7520.,
+        8929.,
+        10945.,
+        13649.,
+        15935.,
+        18159.,
+        20598.,
+        23226.,
+        26987.,
+    ])
+    fit = fit_atg_model.fit_atg_model(xs=xs, ys=ys)
+    assert fit.a == pytest.approx(2498, rel=0.01)
+    assert fit.tg == pytest.approx(7.3, rel=0.01)

--- a/graphs/requirements.txt
+++ b/graphs/requirements.txt
@@ -4,3 +4,5 @@ numpy
 pandas
 protobuf
 plotly
+pytest
+scipy


### PR DESCRIPTION
Uses `scipy.optimize.least_squares` to find best fit.

I want to test on real data before merging.

[Technical] I am also considering optimising directly in the log space (as in finding log(A) and log(TG)). This could improve numerical stability of the optimisation since both A and TG are "multiplicative" parameters.