### PR TITLE
Can't install python packages with old version of setuptools

### DIFF
--- a/covid_graphs/README.md
+++ b/covid_graphs/README.md
@@ -15,6 +15,7 @@ environment, install the `covid_graphs` package an run the server.
 ```sh
 python3.7 -m venv your/path/to/venv
 source your/path/to/venv/bin/activate
+pip install --upgrade setuptools
 pip install -e . # With -e the package will automatically reload with any local changes.
 covid_graphs.run_server --data-dir data/ --simulated-polynomial data/results-poly.pb --simulated-exponential data/results-exp.pb
 ```


### PR DESCRIPTION
If you follow the manual python installation instructions, you may get the following error:

```
ImportError: cannot import name 'find_namespace_packages' from 'setuptools'
```

This is fixed by updating the setuptools package.