### PR TITLE
Create separate dashboards for different prediction events.

### DIFF
--- a/covid_graphs/covid_graphs/country_graph.py
+++ b/covid_graphs/covid_graphs/country_graph.py
@@ -10,9 +10,6 @@ from .predictions import prediction_db, CountryPrediction
 from .country_report import CountryReport
 from .formula import Curve, XAxisType
 
-# TODO: Remove after graph display refactoring.
-PREDICTION_DATE = '2020-03-29'
-
 
 class GraphType(Enum):
     Normal = 'normal'
@@ -36,6 +33,10 @@ class CountryGraph:
         # TODO(miskosz): We assume there is only one country.
         # This might change soon though if we want to have a country dropdown in one graph.
         country_name = country_predictions[0].country
+
+        # TODO(lukas): Figure out better strategy for more predictions
+        if len(country_predictions) >= 1:
+            self.prediction_date = country_predictions[0].prediction_event.date.strftime("%Y-%m-%d")
 
         # Due to plotly limitations, we can only have graphs with dates on the x-axis when we
         # aren't using logs.
@@ -72,7 +73,7 @@ class CountryGraph:
                  line=dict(width=2, dash='dot')) for curve in self.curves
         ]
         try:
-            prediction_date = self.date_list.index(PREDICTION_DATE)
+            prediction_date = self.date_list.index(self.prediction_date)
             # Add green zone marking the data available at the prediction date.
             shapes.append(
                 dict(type="rect",

--- a/covid_graphs/covid_graphs/country_graph.py
+++ b/covid_graphs/covid_graphs/country_graph.py
@@ -2,14 +2,11 @@ from enum import Enum
 from plotly.graph_objs import Figure, Layout, Scatter
 import click
 import click_pathlib
-import dash
-import dash_core_components as dcc
-import dash_html_components as html
-from flask import Flask
 import numpy as np
 from pathlib import Path
+from typing import List
 
-from .predictions import prediction_db
+from .predictions import prediction_db, CountryPrediction
 from .country_report import CountryReport
 from .formula import Curve, XAxisType
 
@@ -28,13 +25,24 @@ class GraphType(Enum):
 
 class CountryGraph:
     """Constructs a graph for a given country"""
-    def __init__(self, data_dir: Path, country_name: str, graph_type: GraphType = GraphType.Normal):
-        country_predictions = prediction_db.predictions_for_country(country=country_name)
+    def __init__(
+        self,
+        data_dir: Path,
+        country_predictions: List[CountryPrediction],
+        graph_type: GraphType = GraphType.Normal,
+    ):
         self.graph_type = graph_type
+
+        # TODO(miskosz): We assume there is only one country.
+        # This might change soon though if we want to have a country dropdown in one graph.
+        country_name = country_predictions[0].country
+
         # Due to plotly limitations, we can only have graphs with dates on the x-axis when we
         # aren't using logs.
         axis_type = XAxisType.Dated if graph_type == GraphType.Normal else XAxisType.Numbered
+
         report = CountryReport(country_data_file=data_dir / f'{country_name}.data')
+
         first_idx, last_idx, self.curves = Curve.create_curves(
             [prediction.formula for prediction in country_predictions],
             report.cumulative_active,
@@ -132,79 +140,6 @@ class CountryGraph:
             figure.update_yaxes(type="log")
         return figure
 
-    @staticmethod
-    def create_dashboard(data_dir: Path, server: Flask, graph_type: GraphType = GraphType.Normal):
-        countries = sorted(prediction_db.get_countries())
-        country_graphs = [
-            CountryGraph(data_dir, country_name, graph_type) for country_name in countries
-            if (data_dir / f'{country_name}.data').is_file()
-        ]
-        country_graphs.sort(key=lambda country: country.name)
-
-        app = dash.Dash(
-            name=f'COVID-19 {graph_type}',
-            url_base_pathname=f'/covid19/{graph_type}/',
-            server=server,
-            external_scripts=[
-                'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML'
-            ])
-        app.title = 'COVID-19 predictions'
-        if graph_type != GraphType.Normal:
-            app.title += f' on a {graph_type} graph'
-
-        graphs = [
-            dcc.Graph(id=f'{country_graph.name} {graph_type}',
-                      figure=country_graph.create_country_figure())
-            for country_graph in country_graphs
-        ]
-
-        prediction_link = "https://www.facebook.com/permalink.php?"\
-            "story_fbid=10113020662000793&id=2247644"
-        france_link = "https://www.reuters.com/article/us-health-coronavirus-france-toll/" \
-            "french-coronavirus-cases-jump-above-chinas-after-including-nursing-home-tally-idUSKBN21L3BG"
-        content = [
-            html.H1(children='COVID-19 predictions of Boďová and Kollár'),
-            html.P(children=[
-                'On 2020-03-30, mathematicians Katarína Boďová and Richard Kollár ',
-                html.A('made predictions about 7 countries', href=prediction_link),
-                f'. The data available up to that point (until {PREDICTION_DATE}) is in the ',
-                html.Span('green zone', style={'color': 'green'}),
-                f'. Data coming after {PREDICTION_DATE} is in the ',
-                html.Span('blue zone.', style=dict(color='blue')),
-                dcc.Markdown("""
-                The predicted number of active cases <em>N</em>(<em>t</em>) on day <em>t</em> is
-                calculated as follows (constants <em>A</em> and <em>T</em><sub><em>G</em></sub>
-                are country-specific):
-                <em>N</em>(<em>t</em>) = (<em>A</em>/<em>T</em><sub><em>G</em></sub>) ⋅
-                (<em>t</em>/<em>T</em><sub><em>G</em></sub>)<sup>6.23</sup> /
-                e<sup><em>t</em>/<em>T</em><sub><em>G</em></sub></sup>
-                """,
-                             dangerously_allow_html=True)
-            ]),
-            dcc.Markdown("""
-                ### References
-                * [Polynomial growth in age-dependent branching processes with diverging
-                  reproductive number](https://arxiv.org/abs/cond-mat/0505116) by Alexei Vazquez
-                * [Fractal kinetics of COVID-19 pandemic]
-                  (https://www.medrxiv.org/content/10.1101/2020.02.16.20023820v2.full.pdf)
-                  by Robert Ziff and Anna Ziff
-                * Unpublished manuscript by Katarína Boďová and Richard Kollár
-                """),
-            dcc.Markdown(f"""
-                ### Notes about the graphs
-
-                * Dashed lines are the predictions, solid red lines are the real active
-                  cases. Black dotted lines mark the predicted maximums.
-                * We've now added new prediction made on 2020-04-13 by the same authors. There's a
-                  second dashed line for Italy, Spain, USA and Germany.
-                * France has been excluded, since they [screwed up daily data reporting]({france_link}).
-                """,
-                         dangerously_allow_html=True)
-        ] + graphs
-
-        app.layout = html.Div(children=content, style={'font-family': 'sans-serif'})
-        return app
-
 
 @click.command(help='COVID-19 country growth visualization')
 @click.argument(
@@ -218,7 +153,8 @@ class CountryGraph:
     type=str,
 )
 def show_country_plot(data_dir: Path, country_name: str):
+    country_predictions = prediction_db.predictions_for_country(country=country_name)
     country_graph = CountryGraph(data_dir=data_dir,
-                                 country_name=country_name,
+                                 country_predictions=country_predictions,
                                  graph_type=GraphType.Normal)
     country_graph.create_country_figure().show()

--- a/covid_graphs/covid_graphs/scripts/country_dashboard.py
+++ b/covid_graphs/covid_graphs/scripts/country_dashboard.py
@@ -1,0 +1,102 @@
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+from flask import Flask
+from pathlib import Path
+
+from covid_graphs.country_graph import CountryGraph, GraphType
+from covid_graphs.predictions import prediction_db, PredictionEvent
+
+
+def create_dashboard(
+    data_dir: Path,
+    server: Flask,
+    prediction_event: PredictionEvent,
+    graph_type: GraphType,
+):
+    # TODO(miskosz): Don't use print.
+    print(f"Creating dashboard for {prediction_event.name} {graph_type} graphs.")
+
+    predictions = prediction_db.predictions_for_event(prediction_event)
+
+    # Note: We silently assume there is only one prediction per country.
+    country_graphs = [
+        CountryGraph(data_dir, [country_prediction], graph_type)
+        for country_prediction in predictions
+        if (data_dir / f'{country_prediction.country}.data').is_file()
+    ]
+    country_graphs.sort(key=lambda graph: graph.name)
+
+    app = dash.Dash(
+        name=f'COVID-19 {graph_type}',
+        url_base_pathname=f'/covid19/{prediction_event.name}/{graph_type}/',
+        server=server,
+        external_scripts=[
+            'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML'
+        ],
+    )
+    app.title = 'COVID-19 predictions'
+    if graph_type != GraphType.Normal:
+        app.title += f' on a {graph_type} graph'
+
+    graphs = [
+        dcc.Graph(id=f'{country_graph.name} {graph_type}',
+                  figure=country_graph.create_country_figure())
+        for country_graph in country_graphs
+    ]
+
+    content = _get_header_content(prediction_event) + graphs
+
+    app.layout = html.Div(children=content, style={'font-family': 'sans-serif'})
+    return app
+
+
+def _get_header_content(prediction_event: PredictionEvent):
+    # TODO: Rewrite the header to be general for both prediction pages.
+    # TODO: Description in the text of this date is wrong.
+    prediction_date_str = prediction_event.date.strftime("%Y-%m-%d")
+    prediction_link = "https://www.facebook.com/permalink.php?"\
+        "story_fbid=10113020662000793&id=2247644"
+    france_link = "https://www.reuters.com/article/us-health-coronavirus-france-toll/" \
+        "french-coronavirus-cases-jump-above-chinas-after-including-nursing-home-tally-idUSKBN21L3BG"
+    return [
+        html.H1(children='COVID-19 predictions of Boďová and Kollár'),
+        html.P(children=[
+            'On 2020-03-30, mathematicians Katarína Boďová and Richard Kollár ',
+            html.A('made predictions about 7 countries', href=prediction_link),
+            f'. The data available up to that point (until {prediction_date_str}) is in the ',
+            html.Span('green zone', style={'color': 'green'}),
+            f'. Data coming after {prediction_date_str} is in the ',
+            html.Span('blue zone.', style=dict(color='blue')),
+            dcc.Markdown(
+                """
+                The predicted number of active cases <em>N</em>(<em>t</em>) on day <em>t</em> is
+                calculated as follows (constants <em>A</em> and <em>T</em><sub><em>G</em></sub>
+                are country-specific):
+                <em>N</em>(<em>t</em>) = (<em>A</em>/<em>T</em><sub><em>G</em></sub>) ⋅
+                (<em>t</em>/<em>T</em><sub><em>G</em></sub>)<sup>6.23</sup> /
+                e<sup><em>t</em>/<em>T</em><sub><em>G</em></sub></sup>
+                """,
+                dangerously_allow_html=True,
+            ),
+        ]),
+        dcc.Markdown("""
+            ### References
+            * [Polynomial growth in age-dependent branching processes with diverging
+              reproductive number](https://arxiv.org/abs/cond-mat/0505116) by Alexei Vazquez
+            * [Fractal kinetics of COVID-19 pandemic]
+              (https://www.medrxiv.org/content/10.1101/2020.02.16.20023820v2.full.pdf)
+              by Robert Ziff and Anna Ziff
+            * Unpublished manuscript by Katarína Boďová and Richard Kollár
+            """),
+        dcc.Markdown(f"""
+            ### Notes about the graphs
+
+            * Dashed lines are the predictions, solid red lines are the real active
+              cases. Black dotted lines mark the predicted maximums.
+            * We've now added new prediction made on 2020-04-13 by the same authors. There's a
+              second dashed line for Italy, Spain, USA and Germany.
+            * France has been excluded, since they [screwed up daily data reporting]({france_link}).
+            """,
+                     dangerously_allow_html=True)
+    ]

--- a/covid_graphs/covid_graphs/scripts/country_dashboard.py
+++ b/covid_graphs/covid_graphs/scripts/country_dashboard.py
@@ -35,7 +35,7 @@ def create_dashboard(
             'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML'
         ],
     )
-    app.title = 'COVID-19 predictions'
+    app.title = 'COVID-19 predictions of Boďová and Kollár'
     if graph_type != GraphType.Normal:
         app.title += f' on a {graph_type} graph'
 
@@ -45,13 +45,13 @@ def create_dashboard(
         for country_graph in country_graphs
     ]
 
-    content = _get_header_content(prediction_event) + graphs
+    content = _get_header_content(prediction_event, app.title) + graphs
 
     app.layout = html.Div(children=content, style={'font-family': 'sans-serif'})
     return app
 
 
-def _get_header_content(prediction_event: PredictionEvent):
+def _get_header_content(prediction_event: PredictionEvent, title: str):
     # TODO: Rewrite the header to be general for both prediction pages.
     # TODO: Description in the text of this date is wrong.
     prediction_date_str = prediction_event.date.strftime("%Y-%m-%d")
@@ -60,7 +60,7 @@ def _get_header_content(prediction_event: PredictionEvent):
     france_link = "https://www.reuters.com/article/us-health-coronavirus-france-toll/" \
         "french-coronavirus-cases-jump-above-chinas-after-including-nursing-home-tally-idUSKBN21L3BG"
     return [
-        html.H1(children='COVID-19 predictions of Boďová and Kollár'),
+        html.H1(children=title),
         html.P(children=[
             'On 2020-03-30, mathematicians Katarína Boďová and Richard Kollár ',
             html.A('made predictions about 7 countries', href=prediction_link),

--- a/covid_graphs/covid_graphs/scripts/country_dashboard.py
+++ b/covid_graphs/covid_graphs/scripts/country_dashboard.py
@@ -62,6 +62,7 @@ def _get_header_content(prediction_event: PredictionEvent, title: str):
     return [
         html.H1(children=title),
         html.P(children=[
+            # TODO: fix the date
             'On 2020-03-30, mathematicians Katarína Boďová and Richard Kollár ',
             html.A('made predictions about 7 countries', href=prediction_link),
             f'. The data available up to that point (until {prediction_date_str}) is in the ',

--- a/covid_graphs/covid_graphs/scripts/index.html
+++ b/covid_graphs/covid_graphs/scripts/index.html
@@ -7,13 +7,20 @@
   </head>
   <body>
     <h1>COVID-19 predictions of Katarína Boďová and Richard Kollár</h1>
-    <p>Predictions for 7 countries plotted on
-      <ul>
-        <li><a href="{{ url_for('covid19_normal') }}">normal graphs</a></li>
-        <li><a href="{{ url_for('covid19_semilog') }}">semi-log graphs</a></li>
-        <li><a href="{{ url_for('covid19_loglog') }}">log-log graphs</a></li>
-      </ul>
-    </p>
+    <ul>
+      <li>
+        Predictions by April 12:
+        (<a href="{{ url_for('covid19_predictions', event='apr12', graph_type='normal') }}">normal graphs</a>)
+        (<a href="{{ url_for('covid19_predictions', event='apr12', graph_type='semilog') }}">semilog graphs</a>)
+        (<a href="{{ url_for('covid19_predictions', event='apr12', graph_type='loglog') }}">loglog graphs</a>)
+      </li>
+      <li>
+        Predictions by March 29:
+        (<a href="{{ url_for('covid19_predictions', event='mar29', graph_type='normal') }}">normal graphs</a>)
+        (<a href="{{ url_for('covid19_predictions', event='mar29', graph_type='semilog') }}">semilog graphs</a>)
+        (<a href="{{ url_for('covid19_predictions', event='mar29', graph_type='loglog') }}">loglog graphs</a>)
+      </li>
+    </ul>
     <h1>
       Visualizations of a COVID-19 stochastic model by Radoslav Harman
     </h1>

--- a/covid_graphs/covid_graphs/scripts/server.py
+++ b/covid_graphs/covid_graphs/scripts/server.py
@@ -49,7 +49,7 @@ def run_server(data_dir: Path, simulated_polynomial: Path, simulated_exponential
     def home():
         return render_template("index.html")
 
-    @server.route("/covid19/")
+    @server.route("/covid19/normal")
     def covid19_redirect():
         return redirect(url_for("covid19_predictions", event="apr12", graph_type="normal"))
 

--- a/covid_graphs/covid_graphs/scripts/server.py
+++ b/covid_graphs/covid_graphs/scripts/server.py
@@ -1,10 +1,16 @@
 import click
 import click_pathlib
+from dash.dash import Dash
 from flask import Flask, render_template, redirect, url_for
+import itertools
+import logging
 from pathlib import Path
 
-from covid_graphs.country_graph import CountryGraph, GraphType
+from covid_graphs.country_graph import GraphType
 from covid_graphs.heat_map import HeatMap
+from covid_graphs import predictions
+
+from . import country_dashboard
 
 
 CURRENT_DIR = Path(__file__).parent
@@ -36,11 +42,8 @@ def run_server(data_dir: Path, simulated_polynomial: Path, simulated_exponential
     """Creates and runs a flask server."""
     server = Flask(__name__, template_folder=CURRENT_DIR)
 
-    covid19_normal_app = CountryGraph.create_dashboard(data_dir, server, GraphType.Normal)
-    covid19_semilog_app = CountryGraph.create_dashboard(data_dir, server, GraphType.SemiLog)
-    covid19_loglog_app = CountryGraph.create_dashboard(data_dir, server, GraphType.LogLog)
-    covid19_heatmap_app = HeatMap(str(simulated_polynomial)).create_app(server)
-    covid19_heatmap_exponential_app = HeatMap(str(simulated_exponential)).create_app(server)
+    _create_prediction_apps(server=server, data_dir=data_dir)
+    _create_simulation_apps(server, simulated_polynomial, simulated_exponential)
 
     @server.route("/")
     def home():
@@ -48,19 +51,44 @@ def run_server(data_dir: Path, simulated_polynomial: Path, simulated_exponential
 
     @server.route("/covid19/")
     def covid19_redirect():
-        return redirect(url_for("covid19_normal"))
+        return redirect(url_for("covid19_predictions", event="apr12", graph_type="normal"))
 
-    @server.route("/covid19/normal")
-    def covid19_normal():
-        return covid19_normal_app.index()
+    server.run(host="0.0.0.0", port=8081, debug=True, extra_files=data_dir.glob("*.data"))
 
-    @server.route("/covid19/semilog")
-    def covid19_semilog():
-        return covid19_semilog_app.index()
 
-    @server.route("/covid19/loglog")
-    def covid19_loglog():
-        return covid19_loglog_app.index()
+def _create_prediction_apps(data_dir: Path, server: Flask):
+    # Note: Event route strings might become part the PredictionEvent class.
+    event_by_route = {
+        "mar29": predictions.BK_20200329,
+        "apr12": predictions.BK_20200412,
+    }
+    graph_type_by_route = {
+        "normal": GraphType.Normal,
+        "semilog": GraphType.SemiLog,
+        "loglog": GraphType.LogLog,
+    }
+    route_pairs = itertools.product(event_by_route.keys(), graph_type_by_route.keys())
+
+    prediction_apps = {
+        (event_route, graph_type_route): country_dashboard.create_dashboard(
+            data_dir=data_dir,
+            server=server,
+            prediction_event=event_by_route[event_route],
+            graph_type=graph_type_by_route[graph_type_route],
+        )
+        for event_route, graph_type_route in route_pairs
+    }
+
+    @server.route("/covid19/predictions/<event>/<graph_type>")
+    def covid19_predictions(event: str, graph_type: str):
+        return prediction_apps[(event, graph_type)].index()
+
+
+def _create_simulation_apps(
+    server: Flask, simulated_polynomial: Path, simulated_exponential: Path
+):
+    covid19_heatmap_app = HeatMap(str(simulated_polynomial)).create_app(server)
+    covid19_heatmap_exponential_app = HeatMap(str(simulated_exponential)).create_app(server)
 
     @server.route("/covid19/heatmap/polynomial")
     def covid19_heatmap_polynomial():
@@ -69,5 +97,3 @@ def run_server(data_dir: Path, simulated_polynomial: Path, simulated_exponential
     @server.route("/covid19/heatmap/exponential")
     def covid19_heatmap_exponential():
         return covid19_heatmap_exponential_app.index()
-
-    server.run(host="0.0.0.0", port=8081, debug=True, extra_files=data_dir.glob("*.data"))


### PR DESCRIPTION
What has changed?

- Moved webpage creation out of `country_graph.py`
- A dashboard is created per *prediction event* and per *graph type*
- Added dashboard links to the index page

What needs to be done in future PRs:

- The text at the top of a graph page does not describe what is going on.