### PR TITLE
Disable zooming and panning

### DIFF
--- a/covid_graphs/covid_graphs/country_graph.py
+++ b/covid_graphs/covid_graphs/country_graph.py
@@ -99,6 +99,7 @@ class CountryGraph:
             title=f"Active cases in {self.long_name}",
             xaxis=dict(
                 autorange=True,
+                fixedrange=True,
                 title=f"Day [starting at the {self.min_case_count}th case]",
                 showgrid=False,
             ),
@@ -107,6 +108,7 @@ class CountryGraph:
                 title=f"COVID-19 active cases in {self.short_name}",
                 gridcolor="LightGray",
                 autorange=(graph_type == GraphType.Normal),
+                fixedrange=True,
                 zerolinecolor="Gray",
             ),
             height=700,


### PR DESCRIPTION
This will apparently disable all zooming and panning of the graphs. I don't think there's any reason people would want to do this and it will make the touch behavior on mobile a little more bearable (and the list of buttons much shorter).