### PR TITLE
Join different graph types into one Dash graph

### DIFF
--- a/covid_graphs/covid_graphs/country_graph.py
+++ b/covid_graphs/covid_graphs/country_graph.py
@@ -155,6 +155,7 @@ class CountryGraph:
         elif graph_type == GraphType.LogLog:
             self.figure.update_xaxes(type="log", title=self.log_title)
             self.figure.update_yaxes(type="log", autorange=False, range=self.log_yrange)
+        return self.figure
 
 
 @click.command(help="COVID-19 country growth visualization")

--- a/covid_graphs/covid_graphs/country_graph.py
+++ b/covid_graphs/covid_graphs/country_graph.py
@@ -13,7 +13,7 @@ from .predictions import CountryPrediction, prediction_db
 
 
 class GraphType(Enum):
-    Normal = "normal"
+    Linear = "linear"
     SemiLog = "semi-log"
     LogLog = "log-log"
 
@@ -45,7 +45,7 @@ class CountryGraph:
         self.cropped_dates = report.dates[min_start_date_idx:]
         self.cropped_cumulative_active = report.cumulative_active[min_start_date_idx:]
 
-    def create_country_figure(self, graph_type=GraphType.Normal):
+    def create_country_figure(self, graph_type=GraphType.Linear):
         log_xaxis_date_since = datetime.date(2020, 2, 1)
 
         def adjust_xlabel(date: datetime.date):
@@ -146,7 +146,7 @@ class CountryGraph:
         return self.figure
 
     def update_graph_type(self, graph_type: GraphType):
-        if graph_type == GraphType.Normal:
+        if graph_type == GraphType.Linear:
             self.figure.update_xaxes(type="date", title=self.date_title)
             self.figure.update_yaxes(type="linear", autorange=True)
         elif graph_type == GraphType.SemiLog:

--- a/covid_graphs/covid_graphs/country_graph.py
+++ b/covid_graphs/covid_graphs/country_graph.py
@@ -38,9 +38,6 @@ class CountryGraph:
             prediction.formula.get_curve(country_report=report)
             for prediction in country_predictions
         ]
-        self.min_case_count = min(
-            prediction.formula.min_case_count for prediction in country_predictions
-        )
 
         # Crop country data to display.
         min_start_date = min(curve.start_date for curve in self.curves)
@@ -142,7 +139,7 @@ class CountryGraph:
             math.log10(maximal_y) + 0.3,
         ]
         self.log_title = f"Days [since {log_xaxis_date_since.strftime('%b %d, %Y')}]"
-        self.date_title = f"Date [starting from {self.min_case_count}th case]"
+        self.date_title = f"Date [starting from {self.cropped_dates[0].strftime('%b %d, %Y')}]"
 
         self.figure = Figure(data=traces, layout=layout)
         self.update_graph_type(graph_type)

--- a/covid_graphs/covid_graphs/predictions.py
+++ b/covid_graphs/covid_graphs/predictions.py
@@ -24,12 +24,6 @@ BK_20200411 = PredictionEvent(name="bk_20200411", date=datetime.date(2020, 4, 11
 OTHER = PredictionEvent(name="other", date=datetime.date(2020, 4, 1))
 
 _prediction_database = [
-    # OTHER
-    # CountryPrediction(
-    #     prediction_event=OTHER,
-    #     country="Slovakia",
-    #     formula=Formula(lambda t: 8 * t ** 1.28, r"$8 \cdot t^{1.28}$", 40, 10),
-    # ),
     # BK_20200329
     CountryPrediction(
         prediction_event=BK_20200329, country="Italy", formula=AtgFormula(7.8, 4417, 6.23, 200),

--- a/covid_graphs/covid_graphs/scripts/country_dashboard.py
+++ b/covid_graphs/covid_graphs/scripts/country_dashboard.py
@@ -111,7 +111,7 @@ class CountryDashboard:
                 id="graph-type",
                 options=[
                     {"label": graph_type.value, "value": graph_type.name}
-                    for graph_type in [GraphType.Normal, GraphType.SemiLog, GraphType.LogLog]
+                    for graph_type in [GraphType.Normal, GraphType.SemiLog]
                 ],
                 value="Normal",
                 labelStyle={"display": "inline-block", "margin": "0 4px 0 0"},

--- a/covid_graphs/covid_graphs/scripts/country_dashboard.py
+++ b/covid_graphs/covid_graphs/scripts/country_dashboard.py
@@ -111,9 +111,9 @@ class CountryDashboard:
                 id="graph-type",
                 options=[
                     {"label": graph_type.value, "value": graph_type.name}
-                    for graph_type in [GraphType.Normal, GraphType.SemiLog]
+                    for graph_type in [GraphType.Linear, GraphType.SemiLog]
                 ],
-                value="Normal",
+                value="Linear",
                 labelStyle={"display": "inline-block", "margin": "0 4px 0 0"},
             ),
         )
@@ -131,9 +131,9 @@ class CountryDashboard:
             ],
             meta_tags=[{"name": "viewport", "content": "width=750"}],
         )
-        content = self._get_header_content(TITLE)
+        content = _get_header_content(TITLE)
         content += [html.Hr(), html.H1(id="graph-title")]
-        content += self._create_buttons(dashboard_type)
+        content += CountryDashboard._create_buttons(dashboard_type)
         content += extra_content
 
         app.title = TITLE
@@ -238,57 +238,58 @@ class CountryDashboard:
                 result.append(graph.figure)
             return result
 
-    def _get_header_content(self, title: str):
-        mar30_prediction_link = (
-            "https://www.facebook.com/permalink.php?story_fbid=10113020662000793&id=2247644"
-        )
-        return [
-            html.H1(children=title),
-            dcc.Markdown(
-                f"""
-                Mathematicians Katarína Boďová and Richard Kollár predicted in March and April 2020
-                the growth of active cases during COVID-19 pandemic. Their model suggests polynomial
-                growth with exponential decay given by:
 
-                * <em>N</em>(<em>t</em>) = (<em>A</em>/<em>T</em><sub><em>G</em></sub>) ⋅
-                  (<em>t</em>/<em>T</em><sub><em>G</em></sub>)<sup>α</sup> /
-                  e<sup><em>t</em>/<em>T</em><sub><em>G</em></sub></sup>
+def _get_header_content(title: str):
+    mar30_prediction_link = (
+        "https://www.facebook.com/permalink.php?story_fbid=10113020662000793&id=2247644"
+    )
+    return [
+        html.H1(children=title),
+        dcc.Markdown(
+            f"""
+            Mathematicians Katarína Boďová and Richard Kollár predicted in March and April 2020
+            the growth of active cases during COVID-19 pandemic. Their model suggests polynomial
+            growth with exponential decay given by:
 
-                Where:
+            * <em>N</em>(<em>t</em>) = (<em>A</em>/<em>T</em><sub><em>G</em></sub>) ⋅
+              (<em>t</em>/<em>T</em><sub><em>G</em></sub>)<sup>α</sup> /
+              e<sup><em>t</em>/<em>T</em><sub><em>G</em></sub></sup>
 
-                * *t* is time in days counted from a country-specific "day one"
-                * *N(t)* the number of active cases (cumulative positively tested minus recovered and deceased)
-                * *A*, *T<sub>G</sub>* and *α* are country-specific parameters
+            Where:
 
-                They made two predictions, on March 30 (for 7 countries) and on April 12 (for 23
-                countries), each based on data available until the day before. The first prediction
-                assumed a common growth parameter *α* = 6.23.
+            * *t* is time in days counted from a country-specific "day one"
+            * *N(t)* the number of active cases (cumulative positively tested minus recovered and deceased)
+            * *A*, *T<sub>G</sub>* and *α* are country-specific parameters
 
-                ### References
-                * [Polynomial growth in age-dependent branching processes with diverging
-                  reproductive number](https://arxiv.org/abs/cond-mat/0505116) by Alexei Vazquez
-                * [Fractal kinetics of COVID-19 pandemic]
-                  (https://www.medrxiv.org/content/10.1101/2020.02.16.20023820v2.full.pdf)
-                  by Robert Ziff and Anna Ziff
-                * Unpublished manuscript by Katarína Boďová and Richard Kollár
-                * March 30 predictions: [Facebook post]({mar30_prediction_link})
-                * April 12 predictions: Personal communication
+            They made two predictions, on March 30 (for 7 countries) and on April 12 (for 23
+            countries), each based on data available until the day before. The first prediction
+            assumed a common growth parameter *α* = 6.23.
 
-                ### Legend
-                """,
-                dangerously_allow_html=True,
-            ),
-            html.Ul(
-                children=[
-                    html.Li("Solid line is prediction"),
-                    html.Li("Dashed line marks the culmination of the prediction"),
-                    html.Li("Red line is observed number of active cases"),
-                    html.Li(
-                        children=[
-                            "Data available until the date of prediction is in ",
-                            html.Span("light green zone", style={"background-color": "lightgreen"}),
-                        ]
-                    ),
-                ]
-            ),
-        ]
+            ### References
+            * [Polynomial growth in age-dependent branching processes with diverging
+              reproductive number](https://arxiv.org/abs/cond-mat/0505116) by Alexei Vazquez
+            * [Fractal kinetics of COVID-19 pandemic]
+              (https://www.medrxiv.org/content/10.1101/2020.02.16.20023820v2.full.pdf)
+              by Robert Ziff and Anna Ziff
+            * Unpublished manuscript by Katarína Boďová and Richard Kollár
+            * March 30 predictions: [Facebook post]({mar30_prediction_link})
+            * April 12 predictions: Personal communication
+
+            ### Legend
+            """,
+            dangerously_allow_html=True,
+        ),
+        html.Ul(
+            children=[
+                html.Li("Solid line is prediction"),
+                html.Li("Dashed line marks the culmination of the prediction"),
+                html.Li("Red line is observed number of active cases"),
+                html.Li(
+                    children=[
+                        "Data available until the date of prediction is in ",
+                        html.Span("light green zone", style={"background-color": "lightgreen"}),
+                    ]
+                ),
+            ]
+        ),
+    ]

--- a/covid_graphs/covid_graphs/scripts/country_dashboard.py
+++ b/covid_graphs/covid_graphs/scripts/country_dashboard.py
@@ -221,8 +221,7 @@ class CountryDashboard:
         def update_country_graphs_20200411(graph_type_str):
             result = []
             for graph in self.graph_dict[BK_20200411.name]:
-                graph.update_graph_type(GraphType[graph_type_str])
-                result.append(graph.figure)
+                result.append(graph.update_graph_type(GraphType[graph_type_str]))
             return result
 
         @self.app.callback(

--- a/covid_graphs/covid_graphs/scripts/country_dashboard.py
+++ b/covid_graphs/covid_graphs/scripts/country_dashboard.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 import dash
 import dash_core_components as dcc
@@ -12,7 +12,7 @@ from flask import Flask
 import covid_graphs.country_report as country_report
 from covid_graphs.country_graph import CountryGraph, GraphType
 from covid_graphs.country_report import CountryReport
-from covid_graphs.predictions import BK_20200411, OTHER, PredictionEvent, prediction_db
+from covid_graphs.predictions import BK_20200329, BK_20200411, OTHER, PredictionEvent, prediction_db
 
 
 class DashboardType(Enum):
@@ -27,248 +27,269 @@ TITLE = "COVID-19 predictions of Boďová and Kollár"
 CountryGraphsByReportName = Dict[str, List[CountryGraph]]
 
 
-def _create_buttons(dashboard_type: DashboardType):
-    buttons = [
-        dcc.Dropdown(
-            id="prediction-event",
-            options=[
-                dict(label=(event.date + timedelta(days=1)).strftime("%B %d"), value=event.name)
-                for event in prediction_db.get_prediction_events()
-                if event != OTHER
-            ],
-            value=BK_20200411.name,
-            style={"width": "220px", "margin": "8px 0"},
-        )
-    ]
-    if dashboard_type == DashboardType.SingleCountry:
-        buttons.append(
-            dcc.Dropdown(
-                id="country-short-name", value="Italy", style={"width": "220px", "margin": "8px 0"}
+class CountryDashboard:
+    def __init__(self, dashboard_type: DashboardType, data_dir: Path, server: Flask):
+        prediction_events = prediction_db.get_prediction_events()
+        prediction_events.sort(key=lambda event: event.date, reverse=True)
+        self.prediction_event_by_name = {
+            prediction_event.name: prediction_event for prediction_event in prediction_events
+        }
+
+        # TODO: parsing the proto can fail
+        reports = [
+            country_report.create_report(
+                data_dir / f"{country_short_name}.data", country_short_name
             )
-        )
-
-    buttons.append(
-        dcc.RadioItems(
-            id="graph-type",
-            options=[
-                {"label": graph_type.value, "value": graph_type.name}
-                for graph_type in [GraphType.Normal, GraphType.SemiLog, GraphType.LogLog]
-            ],
-            value="Normal",
-            labelStyle={"display": "inline-block", "margin": "0 4px 0 0"},
-        ),
-    )
-    return buttons
-
-
-def create_graphs(
-    report_by_short_name: Dict[str, CountryReport], prediction_event: PredictionEvent,
-) -> List[CountryGraph]:
-    # Note: We silently assume there is only one prediction per country.
-    country_graphs = [
-        CountryGraph(report_by_short_name[country_prediction.country], [country_prediction])
-        for country_prediction in prediction_db.predictions_for_event(prediction_event)
-    ]
-    country_graphs.sort(key=lambda graph: graph.short_name)
-    return country_graphs
-
-
-def _prepare_data_structures(
-    data_dir: Path,
-) -> Tuple[Dict[str, PredictionEvent], CountryGraphsByReportName]:
-    prediction_events = prediction_db.get_prediction_events()
-    prediction_events.sort(key=lambda event: event.date, reverse=True)
-    prediction_event_by_name = {
-        prediction_event.name: prediction_event for prediction_event in prediction_events
-    }
-
-    # TODO: parsing the proto can fail
-    reports = [
-        country_report.create_report(data_dir / f"{country_short_name}.data", country_short_name)
-        for country_short_name in prediction_db.get_countries()
-        if (data_dir / f"{country_short_name}.data").is_file()
-    ]
-    report_by_short_name = {report.short_name: report for report in reports}
-    graph_dict = {
-        prediction_event.name: create_graphs(report_by_short_name, prediction_event)
-        for prediction_event in prediction_db.get_prediction_events()
-    }
-    return prediction_event_by_name, graph_dict
-
-
-def _create_dash_app(dashboard_type: DashboardType, server: Flask, extra_content: List[Any]):
-    app = dash.Dash(
-        name=f"COVID-19 predictions",
-        url_base_pathname=f"/covid19/predictions/{dashboard_type}/",
-        server=server,
-        external_scripts=[
-            "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML"
-        ],
-        meta_tags=[{"name": "viewport", "content": "width=750"}],
-    )
-    content = _get_header_content(TITLE)
-    content += [html.Hr(), html.H1(id="graph-title")]
-    content += _create_buttons(dashboard_type)
-    content += extra_content
-
-    app.title = TITLE
-    app.layout = html.Div(
-        children=content,
-        style={
-            "font-family": "sans-serif",
-            "text-size-adjust": "none",
-            "-webkit-text-size-adjust": "none",
-        },
-    )
-    return app
-
-
-def create_single_country_dashboard(data_dir: Path, server: Flask):
-    # TODO(miskosz): Don't use print.
-    print("Creating dashboard for a single country.")
-
-    graph = dcc.Graph(
-        id="country-graph",
-        figure=dict(layout=dict(height=700)),
-        config=dict(modeBarButtons=[["toImage"]]),
-    )
-
-    app = _create_dash_app(DashboardType.SingleCountry, server, extra_content=[graph])
-
-    prediction_event_by_name, graph_dict = _prepare_data_structures(data_dir)
-
-    @app.callback(
-        [
-            Output("country-short-name", component_property="options"),
-            Output("graph-title", component_property="children"),
-        ],
-        [Input("prediction-event", "value")],
-    )
-    def update_event(prediction_event_name):
-        options = [
-            dict(label=graph.long_name, value=graph.short_name)
-            for graph in graph_dict[prediction_event_name]
+            for country_short_name in prediction_db.get_countries()
+            if (data_dir / f"{country_short_name}.data").is_file()
         ]
-        next_day = prediction_event_by_name[prediction_event_name].date + timedelta(days=1)
-        return options, f"{next_day.strftime('%B %d')} predictions"
-
-    @app.callback(
-        Output("country-graph", component_property="figure"),
-        [
-            Input("prediction-event", "value"),
-            Input("graph-type", "value"),
-            Input("country-short-name", "value"),
-        ],
-    )
-    def update_graph(prediction_event_name, graph_type_str, country_short_name):
-        graph_type = GraphType[graph_type_str]
-
-        graphs = [
-            country_graph
-            for country_graph in graph_dict[prediction_event_name]
-            if country_graph.short_name == country_short_name
-        ]
-        if len(graphs) == 0:
-            return dash.no_update
-
-        return graphs[0].create_country_figure(graph_type)
-
-    return app
-
-
-def create_all_countries_dashboard(data_dir: Path, server: Flask):
-    # TODO(miskosz): Don't use print.
-    print("Creating dashboard for all countries.")
-    extra_content = [html.Div(id="country-graphs")]
-
-    app = _create_dash_app(DashboardType.AllCountries, server, extra_content)
-
-    prediction_event_by_name, graph_dict = _prepare_data_structures(data_dir)
-
-    dash_graph_dict = {
-        (prediction_event_name, graph_type.name): [
-            dcc.Graph(
-                id=f"country-graph-{graph.short_name}",
-                figure=graph.create_country_figure(graph_type),
-                config=dict(modeBarButtons=[["toImage"]]),
+        report_by_short_name = {report.short_name: report for report in reports}
+        self.graph_dict = {
+            prediction_event.name: CountryDashboard._create_graphs(
+                report_by_short_name, prediction_event
             )
-            for graph in graph_dict[prediction_event_name]
-        ]
-        for prediction_event_name in prediction_event_by_name.keys()
-        for graph_type in GraphType
-    }
+            for prediction_event in prediction_db.get_prediction_events()
+        }
 
-    @app.callback(
-        [
-            Output("country-graphs", component_property="children"),
-            Output("graph-title", component_property="children"),
-        ],
-        [Input("prediction-event", "value"), Input("graph-type", "value")],
-    )
-    def update_event(prediction_event_name, graph_type_str):
-        graphs = dash_graph_dict[(prediction_event_name, graph_type_str)]
-        next_day = prediction_event_by_name[prediction_event_name].date + timedelta(days=1)
-        return graphs, f"{next_day.strftime('%B %d')} predictions"
-
-
-def _get_header_content(title: str):
-    mar30_prediction_link = (
-        "https://www.facebook.com/permalink.php?story_fbid=10113020662000793&id=2247644"
-    )
-    # france_link = (
-    #     "https://www.reuters.com/article/us-health-coronavirus-france-toll/"
-    #     "french-coronavirus-cases-jump-above-chinas-after-including-nursing-home-tally-idUSKBN21L3BG"
-    # )
-    return [
-        html.H1(children=title),
-        dcc.Markdown(
-            f"""
-            Mathematicians Katarína Boďová and Richard Kollár predicted in March and April 2020
-            the growth of active cases during COVID-19 pandemic. Their model suggests polynomial
-            growth with exponential decay given by:
-
-            * <em>N</em>(<em>t</em>) = (<em>A</em>/<em>T</em><sub><em>G</em></sub>) ⋅
-              (<em>t</em>/<em>T</em><sub><em>G</em></sub>)<sup>α</sup> /
-              e<sup><em>t</em>/<em>T</em><sub><em>G</em></sub></sup>
-
-            Where:
-
-            * *t* is time in days counted from a country-specific "day one"
-            * *N(t)* the number of active cases (cumulative positively tested minus recovered and deceased)
-            * *A*, *T<sub>G</sub>* and *α* are country-specific parameters
-
-            They made two predictions, on March 30 (for 7 countries) and on April 12 (for 23
-            countries), each based on data available until the day before. The first prediction
-            assumed a common growth parameter *α* = 6.23.
-
-            ### References
-            * [Polynomial growth in age-dependent branching processes with diverging
-              reproductive number](https://arxiv.org/abs/cond-mat/0505116) by Alexei Vazquez
-            * [Fractal kinetics of COVID-19 pandemic]
-              (https://www.medrxiv.org/content/10.1101/2020.02.16.20023820v2.full.pdf)
-              by Robert Ziff and Anna Ziff
-            * Unpublished manuscript by Katarína Boďová and Richard Kollár
-            * March 30 predictions: [Facebook post]({mar30_prediction_link})
-            * April 12 predictions: Personal communication
-
-            ### Legend
-            """,
-            dangerously_allow_html=True,
-        ),
-        # TODO: Include these?
-        # ### Notes about the graphs
-        # * France has been excluded, since they [screwed up daily data reporting]({france_link}).
-        html.Ul(
-            children=[
-                html.Li("Solid line is prediction"),
-                html.Li("Dashed line marks the culmination of the prediction"),
-                html.Li("Red line is observed number of active cases"),
-                html.Li(
-                    children=[
-                        "Data available until the date of prediction is in ",
-                        html.Span("light green zone", style={"background-color": "lightgreen"}),
-                    ]
-                ),
+        if dashboard_type == DashboardType.SingleCountry:
+            extra_content = [
+                dcc.Graph(
+                    id="country-graph",
+                    figure=dict(layout=dict(height=700)),
+                    config=dict(modeBarButtons=[["toImage"]]),
+                )
             ]
-        ),
-    ]
+        else:
+            extra_content = [html.Div(id="country-graphs")]
+
+        self.app = self._create_dash_app(dashboard_type, server, extra_content)
+        if dashboard_type == DashboardType.SingleCountry:
+            self._create_single_country_callbacks()
+        else:
+            self._create_all_countries_callbacks()
+
+    def get_app(self):
+        return self.app
+
+    @staticmethod
+    def _create_graphs(
+        report_by_short_name: Dict[str, CountryReport], prediction_event: PredictionEvent,
+    ) -> List[CountryGraph]:
+        # Note: We silently assume there is only one prediction per country.
+        country_graphs = [
+            CountryGraph(report_by_short_name[country_prediction.country], [country_prediction])
+            for country_prediction in prediction_db.predictions_for_event(prediction_event)
+        ]
+        country_graphs.sort(key=lambda graph: graph.short_name)
+        return country_graphs
+
+    @staticmethod
+    def _create_buttons(dashboard_type: DashboardType):
+        buttons = [
+            dcc.Dropdown(
+                id="prediction-event",
+                options=[
+                    dict(label=(event.date + timedelta(days=1)).strftime("%B %d"), value=event.name)
+                    for event in prediction_db.get_prediction_events()
+                    if event != OTHER
+                ],
+                value=BK_20200411.name,
+                style={"width": "220px", "margin": "8px 0"},
+            )
+        ]
+        if dashboard_type == DashboardType.SingleCountry:
+            buttons.append(
+                dcc.Dropdown(
+                    id="country-short-name",
+                    value="Italy",
+                    style={"width": "220px", "margin": "8px 0"},
+                )
+            )
+
+        buttons.append(
+            dcc.RadioItems(
+                id="graph-type",
+                options=[
+                    {"label": graph_type.value, "value": graph_type.name}
+                    for graph_type in [GraphType.Normal, GraphType.SemiLog, GraphType.LogLog]
+                ],
+                value="Normal",
+                labelStyle={"display": "inline-block", "margin": "0 4px 0 0"},
+            ),
+        )
+        return buttons
+
+    def _create_dash_app(
+        self, dashboard_type: DashboardType, server: Flask, extra_content: List[Any]
+    ):
+        app = dash.Dash(
+            name=f"COVID-19 predictions",
+            url_base_pathname=f"/covid19/predictions/{dashboard_type}/",
+            server=server,
+            external_scripts=[
+                "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML"
+            ],
+            meta_tags=[{"name": "viewport", "content": "width=750"}],
+        )
+        content = self._get_header_content(TITLE)
+        content += [html.Hr(), html.H1(id="graph-title")]
+        content += self._create_buttons(dashboard_type)
+        content += extra_content
+
+        app.title = TITLE
+        app.layout = html.Div(
+            children=content,
+            style={
+                "font-family": "sans-serif",
+                "text-size-adjust": "none",
+                "-webkit-text-size-adjust": "none",
+            },
+        )
+        return app
+
+    def _create_single_country_callbacks(self):
+        @self.app.callback(
+            [
+                Output("country-short-name", component_property="options"),
+                Output("graph-title", component_property="children"),
+            ],
+            [Input("prediction-event", "value")],
+        )
+        def update_event(prediction_event_name):
+            options = [
+                dict(label=graph.long_name, value=graph.short_name)
+                for graph in self.graph_dict[prediction_event_name]
+            ]
+            next_day = self.prediction_event_by_name[prediction_event_name].date + timedelta(days=1)
+            return options, f"{next_day.strftime('%B %d')} predictions"
+
+        @self.app.callback(
+            Output("country-graph", component_property="figure"),
+            [
+                Input("prediction-event", "value"),
+                Input("graph-type", "value"),
+                Input("country-short-name", "value"),
+            ],
+        )
+        def update_graph(prediction_event_name, graph_type_str, country_short_name):
+            graph_type = GraphType[graph_type_str]
+
+            graphs = [
+                country_graph
+                for country_graph in self.graph_dict[prediction_event_name]
+                if country_graph.short_name == country_short_name
+            ]
+            if len(graphs) == 0:
+                return dash.no_update
+
+            figure = graphs[0].create_country_figure(graph_type)
+            return figure
+
+    def _create_all_countries_callbacks(self):
+        dash_graph_dict = {
+            prediction_event_name: [
+                dcc.Graph(
+                    id=f"{graph.short_name}-graph-{prediction_event_name}",
+                    figure=graph.create_country_figure(),
+                    config=dict(modeBarButtons=[["toImage"]]),
+                )
+                for graph in self.graph_dict[prediction_event_name]
+            ]
+            for prediction_event_name in self.prediction_event_by_name.keys()
+        }
+
+        @self.app.callback(
+            [
+                Output("country-graphs", component_property="children"),
+                Output("graph-title", component_property="children"),
+            ],
+            [Input("prediction-event", "value")],
+        )
+        def update_event(prediction_event_name):
+            graphs = dash_graph_dict[prediction_event_name]
+            next_day = self.prediction_event_by_name[prediction_event_name].date + timedelta(days=1)
+            return graphs, f"{next_day.strftime('%B %d')} predictions"
+
+        # TODO(lukas): only have one callback for all prediction events
+        @self.app.callback(
+            [
+                Output(f"{graph.short_name}-graph-{BK_20200411.name}", component_property="figure")
+                for graph in self.graph_dict[BK_20200411.name]
+            ],
+            [Input("graph-type", "value")],
+        )
+        def update_country_graphs_20200411(graph_type_str):
+            result = []
+            for graph in self.graph_dict[BK_20200411.name]:
+                graph.update_graph_type(GraphType[graph_type_str])
+                result.append(graph.figure)
+            return result
+
+        @self.app.callback(
+            [
+                Output(f"{graph.short_name}-graph-{BK_20200329.name}", component_property="figure")
+                for graph in self.graph_dict[BK_20200329.name]
+            ],
+            [Input("graph-type", "value")],
+        )
+        def update_country_graphs_20200329(graph_type_str):
+            result = []
+            for graph in self.graph_dict[BK_20200329.name]:
+                graph.update_graph_type(GraphType[graph_type_str])
+                result.append(graph.figure)
+            return result
+
+    def _get_header_content(self, title: str):
+        mar30_prediction_link = (
+            "https://www.facebook.com/permalink.php?story_fbid=10113020662000793&id=2247644"
+        )
+        return [
+            html.H1(children=title),
+            dcc.Markdown(
+                f"""
+                Mathematicians Katarína Boďová and Richard Kollár predicted in March and April 2020
+                the growth of active cases during COVID-19 pandemic. Their model suggests polynomial
+                growth with exponential decay given by:
+
+                * <em>N</em>(<em>t</em>) = (<em>A</em>/<em>T</em><sub><em>G</em></sub>) ⋅
+                  (<em>t</em>/<em>T</em><sub><em>G</em></sub>)<sup>α</sup> /
+                  e<sup><em>t</em>/<em>T</em><sub><em>G</em></sub></sup>
+
+                Where:
+
+                * *t* is time in days counted from a country-specific "day one"
+                * *N(t)* the number of active cases (cumulative positively tested minus recovered and deceased)
+                * *A*, *T<sub>G</sub>* and *α* are country-specific parameters
+
+                They made two predictions, on March 30 (for 7 countries) and on April 12 (for 23
+                countries), each based on data available until the day before. The first prediction
+                assumed a common growth parameter *α* = 6.23.
+
+                ### References
+                * [Polynomial growth in age-dependent branching processes with diverging
+                  reproductive number](https://arxiv.org/abs/cond-mat/0505116) by Alexei Vazquez
+                * [Fractal kinetics of COVID-19 pandemic]
+                  (https://www.medrxiv.org/content/10.1101/2020.02.16.20023820v2.full.pdf)
+                  by Robert Ziff and Anna Ziff
+                * Unpublished manuscript by Katarína Boďová and Richard Kollár
+                * March 30 predictions: [Facebook post]({mar30_prediction_link})
+                * April 12 predictions: Personal communication
+
+                ### Legend
+                """,
+                dangerously_allow_html=True,
+            ),
+            html.Ul(
+                children=[
+                    html.Li("Solid line is prediction"),
+                    html.Li("Dashed line marks the culmination of the prediction"),
+                    html.Li("Red line is observed number of active cases"),
+                    html.Li(
+                        children=[
+                            "Data available until the date of prediction is in ",
+                            html.Span("light green zone", style={"background-color": "lightgreen"}),
+                        ]
+                    ),
+                ]
+            ),
+        ]

--- a/covid_graphs/covid_graphs/scripts/server.py
+++ b/covid_graphs/covid_graphs/scripts/server.py
@@ -10,7 +10,7 @@ from inotify import adapters, constants
 from covid_graphs.heat_map import create_heat_map_dashboard
 from covid_graphs.simulation_report import GrowthType
 
-from . import country_dashboard
+from .country_dashboard import CountryDashboard, DashboardType
 
 CURRENT_DIR = Path(__file__).parent
 
@@ -63,12 +63,12 @@ def _run_flask_server(server: Flask, data_dir: Path):
 
 
 def _create_prediction_apps(data_dir: Path, server: Flask):
-    single_prediction_app = country_dashboard.create_single_country_dashboard(
-        data_dir=data_dir, server=server
-    )
-    all_predictions_app = country_dashboard.create_all_countries_dashboard(
-        data_dir=data_dir, server=server
-    )
+    single_prediction_app = CountryDashboard(
+        DashboardType.SingleCountry, data_dir=data_dir, server=server
+    ).get_app()
+    all_predictions_app = CountryDashboard(
+        DashboardType.AllCountries, data_dir=data_dir, server=server
+    ).get_app()
 
     @server.route("/covid19/predictions/single/")
     def covid19_single_predictions():


### PR DESCRIPTION
Previously we had multiple instances of Dash graphs, but this consumes
too much memory and makes the UI slower.

I've measured it and we've saved 40% memory.

There is one regression: I've dropped log-log graphs from the dashboards, since they need special treatment because of Plotly limitations. They still work in `show_country_plot` though.