### PR TITLE
A stable test for optimisation.

### DIFF
--- a/covid_graphs/covid_graphs/fit_atg_model.py
+++ b/covid_graphs/covid_graphs/fit_atg_model.py
@@ -30,7 +30,7 @@ def fit_atg_model(xs: np.ndarray, ys: np.ndarray) -> AtgModelFit:
     least_squares_result = least_squares(
         fun=_residuals,
         x0=[a_init, tg_init, exp_init, t0_init],
-        bounds=([0.0, 0.0, 0.0, -np.inf], np.inf),
+        bounds=([0.0, 0.0, 0.0, xs[0]], np.inf),
         args=(xs, ys),
     )
     a, tg, exp, t0 = least_squares_result.x

--- a/covid_graphs/covid_graphs/fit_atg_model_test.py
+++ b/covid_graphs/covid_graphs/fit_atg_model_test.py
@@ -22,41 +22,19 @@ def test_fit_atg_model():
     fit = fit_atg_model.fit_atg_model(xs=xs, ys=ys)
     assert [fit.a, fit.tg, fit.exp, fit.t0] == pytest.approx([a, tg, exp, t0], rel=0.1)
 
-    # Test with real-world data. (UK active since 2020-3-7.)
-    xs = np.arange(1, 27)
+    # Test with real-world data. (Jordan until 2020-4-23.)
+    # fmt: off
     ys = np.array(
         [
-            186.0,
-            252.0,
-            299.0,
-            358.0,
-            430.0,
-            430.0,
-            772.0,
-            1101.0,
-            1101.0,
-            1468.0,
-            1843.0,
-            2490.0,
-            2487.0,
-            3741.0,
-            4720.0,
-            5337.0,
-            6250.0,
-            7520.0,
-            8929.0,
-            10945.0,
-            13649.0,
-            15935.0,
-            18159.0,
-            20598.0,
-            23226.0,
-            26987.0,
+            0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 7, 16, 33, 51, 68, 84, 84, 111, 126, 153, 171,
+            211, 216, 227, 238, 237, 239, 237, 249, 247, 244, 230, 217, 209, 202, 204, 195, 197,
+            181, 169, 155, 144, 136, 135, 137, 134, 136, 124, 113, 112,
         ]
     )
+    # fmt: on
+    xs = np.arange(len(ys))
     fit = fit_atg_model.fit_atg_model(xs=xs, ys=ys)
-    # TODO(miskosz): Use a country that is after IP for a stable fit.
-    assert [fit.a, fit.tg, fit.exp, fit.t0] == pytest.approx([10, 10, 9, -18], abs=1.0)
+    assert [fit.a, fit.tg, fit.exp, fit.t0] == pytest.approx([2243, 7, 2, 11], abs=1.0)
 
 
 def test_atg_model_fit_predict():

--- a/covid_graphs/covid_graphs/formula.py
+++ b/covid_graphs/covid_graphs/formula.py
@@ -110,7 +110,7 @@ class FittedFormula(Formula):
         until_idx = country_report.dates.index(self.until_date)
 
         # The choice of date zero is in theory arbitrary.
-        date_zero = datetime.date(2020, 2, 1)
+        date_zero = country_report.dates[0]
         xs = [(date - date_zero).days for date in country_report.dates[: until_idx + 1]]
         fit = fit_atg_model.fit_atg_model(
             xs=xs, ys=country_report.cumulative_active[: until_idx + 1],


### PR DESCRIPTION
Also:
* Limits `t0` to be within data (seems this is the case, since BK choose `t0` using min_case_count)
* A less arbitrary date-to-float conversion before optimisation.