### PR TITLE
Separate displaying logic from curve/trace computations

### DIFF
--- a/covid_graphs/covid_graphs/country_graph.py
+++ b/covid_graphs/covid_graphs/country_graph.py
@@ -74,7 +74,7 @@ class CountryGraph:
         # 1. A formula is first shifted to the appropriate date on the graph, creating a
         #    trace generator.
         # 2. The trace generators are used to calculate the last date of the graph, since each trace
-        #    generators stores the minimal display length of its trace.
+        #    generator stores the minimal display length of its trace.
         # 3. Once we know the date range of the graph, we can plot the formulas, creating traces.
         trace_generators = [
             prediction.formula.get_trace_generator(country_report=report)

--- a/covid_graphs/covid_graphs/country_graph.py
+++ b/covid_graphs/covid_graphs/country_graph.py
@@ -1,15 +1,17 @@
 import datetime
 import math
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import List, Tuple
 
 import click
 import click_pathlib
+import numpy as np
 from plotly.graph_objs import Figure, Layout, Scatter
 
 from .country_report import CountryReport, create_report
-from .formula import Curve, FittedFormula
+from .formula import FittedFormula, TraceGenerator
 from .predictions import CountryPrediction, PredictionEvent, prediction_db
 
 EXTENSION_PERIOD = datetime.timedelta(days=7)
@@ -24,17 +26,35 @@ class GraphType(Enum):
         return self.value
 
 
+@dataclass
+class Trace:
+    xs: List[datetime.date]
+    ys: np.ndarray
+    x_max: datetime.date
+    y_max: float
+    label: str
+
+
+def _create_trace(trace_generator: TraceGenerator, display_until: datetime.date) -> Trace:
+    xs, ys = trace_generator.generate_trace(display_until)
+    idx_max = ys.argmax()
+    x_max, y_max = xs[idx_max], ys[idx_max]
+    return Trace(xs, ys, x_max, y_max, label=trace_generator.label)
+
+
 def _get_display_range(
-    report: CountryReport, curves: List[Curve]
+    report: CountryReport, trace_generators: List[TraceGenerator]
 ) -> Tuple[datetime.date, datetime.date]:
-    start_date = min(curve.start_date for curve in curves)
+    start_date = min(trace_generator.start_date for trace_generator in trace_generators)
 
     display_until = max(
-        max(curve.display_at_least_until for curve in curves), report.dates[-1] + EXTENSION_PERIOD,
+        max(trace_generator.display_at_least_until for trace_generator in trace_generators),
+        report.dates[-1] + EXTENSION_PERIOD,
     )
     return start_date, display_until
 
 
+# @dataclass
 class CountryGraph:
     """Constructs a graph for a given country"""
 
@@ -44,48 +64,64 @@ class CountryGraph:
         self.short_name = report.short_name
         self.long_name = report.long_name
 
-        # TODO(lukas): Figure out better strategy for more predictions
         if len(country_predictions) >= 1:
-            self.prediction_date = country_predictions[0].prediction_event.date
+            self.prediction_date = max(
+                country_prediction.prediction_event.date
+                for country_prediction in country_predictions
+            )
 
-        self.curves = [
-            prediction.formula.get_curve(country_report=report)
+        # We create traces in three steps:
+        # 1. A formula is first shifted to the appropriate date on the graph, creating a
+        #    trace generator.
+        # 2. The trace generators are used to calculate the last date of the graph, since each trace
+        #    generators stores the minimal display length of its trace.
+        # 3. Once we know the date range of the graph, we can plot the formulas, creating traces.
+        trace_generators = [
+            prediction.formula.get_trace_generator(country_report=report)
             for prediction in country_predictions
         ]
+        start_date, display_until = _get_display_range(report, trace_generators)
 
-        min_start_date, self.display_until = _get_display_range(report, self.curves)
-        min_start_date_idx = report.dates.index(min_start_date)
+        self.traces = [
+            _create_trace(trace_generator, display_until) for trace_generator in trace_generators
+        ]
+
+        start_date_idx = report.dates.index(start_date)
         # Crop country data to display.
-        self.cropped_dates = report.dates[min_start_date_idx:]
-        self.cropped_cumulative_active = report.cumulative_active[min_start_date_idx:]
+        self.cropped_dates = report.dates[start_date_idx:]
+        self.cropped_cumulative_active = report.cumulative_active[start_date_idx:]
+        self.log_xaxis_date_since = self.cropped_dates[0] - datetime.timedelta(days=1)
+        self.log_title = f"Days [since {self.log_xaxis_date_since.strftime('%b %d, %Y')}]"
+        self.date_title = f"Date [starting from {self.cropped_dates[0].strftime('%b %d, %Y')}]"
+
+        maximal_y = max(
+            max(self.cropped_cumulative_active), max(trace.y_max for trace in self.traces)
+        )
+        self.log_yrange = [
+            math.log10(max(1, self.cropped_cumulative_active.min())) - 0.3,
+            math.log10(maximal_y) + 0.3,
+        ]
 
     def create_country_figure(self, graph_type=GraphType.Linear):
-        log_xaxis_date_since = self.cropped_dates[0] - datetime.timedelta(days=1)
-
         def adjust_xlabel(date: datetime.date):
             # Due to plotly limitations, we can only have graphs with dates on the x-axis when we
             # x-axis isn't log-scale.
             if graph_type != GraphType.LogLog:
                 return date
             else:
-                return (date - log_xaxis_date_since).days
+                return (date - self.log_xaxis_date_since).days
 
-        colors = ["SteelBlue", "Purple", "Green", "Orange", "Gray"][: len(self.curves)]
+        colors = ["SteelBlue", "Purple", "Green", "Orange", "Gray"][: len(self.traces)]
 
         traces, shapes = [], []
-        maximal_y = max(self.cropped_cumulative_active)
-        for color, curve in zip(colors, self.curves):
-            xs, ys = curve.generate_trace(self.display_until)
-            idx_max = ys.argmax()
-            maximal_y = max(maximal_y, ys.max())
-
+        for color, trace in zip(colors, self.traces):
             traces.append(
                 Scatter(
-                    x=list(map(adjust_xlabel, xs)),
-                    y=ys,
-                    text=xs,
+                    x=list(map(adjust_xlabel, trace.xs)),
+                    y=trace.ys,
+                    text=trace.xs,
                     mode="lines",
-                    name=curve.label,
+                    name=trace.label,
                     line={"width": 2, "color": color},
                 )
             )
@@ -93,10 +129,10 @@ class CountryGraph:
             shapes.append(
                 dict(
                     type="line",
-                    x0=adjust_xlabel(xs[idx_max]),
+                    x0=adjust_xlabel(trace.x_max),
                     y0=1,
-                    x1=adjust_xlabel(xs[idx_max]),
-                    y1=ys.max(),
+                    x1=adjust_xlabel(trace.x_max),
+                    y1=trace.y_max,
                     line=dict(width=2, dash="dash", color=color),
                 )
             )
@@ -143,17 +179,8 @@ class CountryGraph:
             plot_bgcolor="White",
         )
 
-        # Note: We silently assume `self.cropped_cumulative_active` does not contain zeros.
-        self.log_yrange = [
-            math.log10(max(1, self.cropped_cumulative_active.min())) - 0.3,
-            math.log10(maximal_y) + 0.3,
-        ]
-        self.log_title = f"Days [since {log_xaxis_date_since.strftime('%b %d, %Y')}]"
-        self.date_title = f"Date [starting from {self.cropped_dates[0].strftime('%b %d, %Y')}]"
-
         self.figure = Figure(data=traces, layout=layout)
-        self.update_graph_type(graph_type)
-        return self.figure
+        return self.update_graph_type(graph_type)
 
     def update_graph_type(self, graph_type: GraphType):
         if graph_type == GraphType.Linear:

--- a/covid_graphs/covid_graphs/formula.py
+++ b/covid_graphs/covid_graphs/formula.py
@@ -2,12 +2,21 @@ import datetime
 import math
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Callable, List, Tuple
+from typing import Callable, List
 
 import numpy as np
 
 from . import fit_atg_model
 from .country_report import CountryReport
+
+
+@dataclass
+class Trace:
+    xs: List[datetime.date]
+    ys: np.ndarray
+    max_value_date: datetime.date
+    max_value: float
+    label: str
 
 
 @dataclass
@@ -22,12 +31,14 @@ class TraceGenerator:
     x >= 0.
     """
 
-    def generate_trace(self, end_date: datetime.date) -> Tuple[List[datetime.date], np.ndarray]:
+    def generate_trace(self, display_until: datetime.date) -> Trace:
         """Generates trace corresponding to the closed interval [self.start_date, end_date]"""
-        raw_xs = np.arange((end_date - self.start_date).days + 1)
+        raw_xs = np.arange((display_until - self.start_date).days + 1)
         ys = np.array([self.func(x) for x in raw_xs])
         xs = [self.start_date + datetime.timedelta(days=int(x)) for x in raw_xs]
-        return xs, ys
+        idx_max = ys.argmax()
+        max_value_date, max_value = xs[idx_max], ys[idx_max]
+        return Trace(xs, ys, max_value_date, max_value, label=self.label)
 
 
 class Formula:

--- a/covid_graphs/covid_graphs/formula_test.py
+++ b/covid_graphs/covid_graphs/formula_test.py
@@ -4,11 +4,12 @@ import math
 import numpy as np
 import pytest
 
+from .country_graph import _create_trace
 from .country_report import CountryReport
 from .formula import AtgFormula
 
 
-def test_two_curves():
+def test_two_traces():
     cumulative_active = np.array([0, 0, 1, 2, 5, 18, 45])
     start_date = datetime.date(2020, 4, 17)
     dates = [start_date + datetime.timedelta(days=d) for d in range(len(cumulative_active))]
@@ -22,26 +23,27 @@ def test_two_curves():
         daily_active=None,
         cumulative_active=cumulative_active,
     )
+    display_until = datetime.date(2020, 4, 30)
 
     f1 = AtgFormula(tg=2, a=47, exponent=1.5, min_case_count=2)
-    # The curve starts (t=0) at 2020-04-19. The maximum of this curve is at t = TG * exponent = 3.
+    # The trace starts (t=0) at 2020-04-19. The maximum of this trace is at t = TG * exponent = 3.
     max_t1, start_date1 = 3, datetime.date(2020, 4, 19)
     length1 = math.ceil(2 * (1.5 + math.sqrt(1.5)))
 
     f2 = AtgFormula(tg=3, a=12, exponent=2, min_case_count=1)
-    # The curve starts (t=0) at 2020-04-18. The maximum of this curve is at t = TG * exponent = 6.
+    # The trace starts (t=0) at 2020-04-18. The maximum of this trace is at t = TG * exponent = 6.
     max_t2, start_date2, length2 = 6, datetime.date(2020, 4, 18), math.ceil(3 * (2 + math.sqrt(2)))
 
-    curve1 = f1.get_curve(report)
-    xs, ys = curve1.generate_trace(datetime.date(2020, 4, 30))
-    assert ys.max() == pytest.approx((47 / 2) * (max_t1 / 2) ** 1.5 * math.exp(-max_t1 / 2))
-    assert curve1.start_date == start_date1
-    assert xs[ys.argmax()] == start_date1 + datetime.timedelta(days=max_t1)
-    assert curve1.display_at_least_until == curve1.start_date + datetime.timedelta(days=length1)
+    trace_generator1 = f1.get_trace_generator(report)
+    trace1 = _create_trace(trace_generator1, display_until)
+    assert trace1.y_max == pytest.approx((47 / 2) * (max_t1 / 2) ** 1.5 * math.exp(-max_t1 / 2))
+    assert trace1.x_max == start_date1 + datetime.timedelta(days=max_t1)
+    assert trace1.xs[0] == start_date1
+    assert trace_generator1.display_at_least_until == start_date1 + datetime.timedelta(days=length1)
 
-    curve2 = f2.get_curve(report)
-    xs, ys = curve2.generate_trace(datetime.date(2020, 4, 30))
-    assert ys.max() == pytest.approx((12 / 3) * (max_t2 / 3) ** 2 * math.exp(-max_t2 / 3))
-    assert curve2.start_date == start_date2
-    assert xs[ys.argmax()] == curve2.start_date + datetime.timedelta(days=max_t2)
-    assert curve2.display_at_least_until == curve2.start_date + datetime.timedelta(days=length2)
+    trace_generator2 = f2.get_trace_generator(report)
+    trace2 = _create_trace(trace_generator2, display_until)
+    assert trace2.y_max == pytest.approx((12 / 3) * (max_t2 / 3) ** 2 * math.exp(-max_t2 / 3))
+    assert trace2.x_max == start_date2 + datetime.timedelta(days=max_t2)
+    assert trace2.xs[0] == start_date2
+    assert trace_generator2.display_at_least_until == start_date2 + datetime.timedelta(days=length2)

--- a/covid_graphs/covid_graphs/formula_test.py
+++ b/covid_graphs/covid_graphs/formula_test.py
@@ -4,7 +4,6 @@ import math
 import numpy as np
 import pytest
 
-from .country_graph import _create_trace
 from .country_report import CountryReport
 from .formula import AtgFormula
 
@@ -35,15 +34,15 @@ def test_two_traces():
     max_t2, start_date2, length2 = 6, datetime.date(2020, 4, 18), math.ceil(3 * (2 + math.sqrt(2)))
 
     trace_generator1 = f1.get_trace_generator(report)
-    trace1 = _create_trace(trace_generator1, display_until)
-    assert trace1.y_max == pytest.approx((47 / 2) * (max_t1 / 2) ** 1.5 * math.exp(-max_t1 / 2))
-    assert trace1.x_max == start_date1 + datetime.timedelta(days=max_t1)
+    trace1 = trace_generator1.generate_trace(display_until)
+    assert trace1.max_value == pytest.approx((47 / 2) * (max_t1 / 2) ** 1.5 * math.exp(-max_t1 / 2))
+    assert trace1.max_value_date == start_date1 + datetime.timedelta(days=max_t1)
     assert trace1.xs[0] == start_date1
     assert trace_generator1.display_at_least_until == start_date1 + datetime.timedelta(days=length1)
 
     trace_generator2 = f2.get_trace_generator(report)
-    trace2 = _create_trace(trace_generator2, display_until)
-    assert trace2.y_max == pytest.approx((12 / 3) * (max_t2 / 3) ** 2 * math.exp(-max_t2 / 3))
-    assert trace2.x_max == start_date2 + datetime.timedelta(days=max_t2)
+    trace2 = trace_generator2.generate_trace(display_until)
+    assert trace2.max_value == pytest.approx((12 / 3) * (max_t2 / 3) ** 2 * math.exp(-max_t2 / 3))
+    assert trace2.max_value_date == start_date2 + datetime.timedelta(days=max_t2)
     assert trace2.xs[0] == start_date2
     assert trace_generator2.display_at_least_until == start_date2 + datetime.timedelta(days=length2)

--- a/covid_graphs/covid_graphs/scripts/rest.py
+++ b/covid_graphs/covid_graphs/scripts/rest.py
@@ -58,19 +58,18 @@ class Rest:
                 "short_name": country_report.short_name,
                 "long_name": country_report.long_name,
             }
-            for prediction, curve in zip(country_predictions, graph.curves):
-                xs, ys = curve.generate_trace(graph.display_until)
-                idx_max = ys.argmax()
+            # Here we assume that traces and country_predictions are in the same order
+            for prediction, trace in zip(country_predictions, graph.traces):
                 predictions.append(
                     {
                         "type": "prediction",
-                        "date_list": xs,
-                        "values": ys.tolist(),
-                        "description": curve.label,
+                        "date_list": trace.xs,
+                        "values": trace.ys.tolist(),
+                        "description": trace.label,
                         "short_name": country_report.short_name,
                         "long_name": country_report.long_name,
-                        "max_value_date": xs[idx_max],
-                        "max_value": ys.max(),
+                        "max_value_date": trace.x_max,
+                        "max_value": trace.y_max,
                         "date_name": prediction.prediction_event.name,
                         "date": prediction.prediction_event.date,
                     }

--- a/covid_graphs/covid_graphs/scripts/rest.py
+++ b/covid_graphs/covid_graphs/scripts/rest.py
@@ -68,8 +68,8 @@ class Rest:
                         "description": trace.label,
                         "short_name": country_report.short_name,
                         "long_name": country_report.long_name,
-                        "max_value_date": trace.x_max,
-                        "max_value": trace.y_max,
+                        "max_value_date": trace.max_value_date,
+                        "max_value": trace.max_value,
                         "date_name": prediction.prediction_event.name,
                         "date": prediction.prediction_event.date,
                     }


### PR DESCRIPTION
I'm now using the synonym trace, since it's a nice sign that we switched the API. There isn't much else behind the name change from `Curve` to `Trace`.